### PR TITLE
Add ability to mint from seed (BIP44 mint data)

### DIFF
--- a/bitcoin/arith_uint256.cpp
+++ b/bitcoin/arith_uint256.cpp
@@ -147,13 +147,14 @@ double base_uint<BITS>::getdouble() const
 template <unsigned int BITS>
 std::string base_uint<BITS>::GetHex() const
 {
-    return ArithToUint256(*this).GetHex();
+    return ArithToUint(*this).GetHex();
 }
 
 template <unsigned int BITS>
 void base_uint<BITS>::SetHex(const char* psz)
 {
-    *this = UintToArith256(uint256S(psz));
+    base_blob<BITS> a;
+    *this = UintToArith(a.uintS(psz));
 }
 
 template <unsigned int BITS>
@@ -183,6 +184,24 @@ unsigned int base_uint<BITS>::bits() const
     return 0;
 }
 
+template <unsigned int BITS>
+base_uint<BITS> base_uint<BITS>::UintToArith(const base_blob<BITS>& a) const
+{
+    base_uint<BITS> b;
+    for(int x=0; x<b.WIDTH; ++x)
+        b.pn[x] = ReadLE32(a.begin() + x*4);
+    return b;
+}
+
+ template <unsigned int BITS>
+base_blob<BITS> base_uint<BITS>::ArithToUint(const base_uint<BITS>& a) const
+{
+    base_blob<BITS> b;
+    for(int x=0; x<a.WIDTH; ++x)
+        WriteLE32(b.begin() + x*4, a.pn[x]);
+    return b;
+}
+
 // Explicit instantiations for base_uint<256>
 template base_uint<256>::base_uint(const std::string&);
 template base_uint<256>& base_uint<256>::operator<<=(unsigned int);
@@ -198,6 +217,8 @@ template std::string base_uint<256>::ToString() const;
 template void base_uint<256>::SetHex(const char*);
 template void base_uint<256>::SetHex(const std::string&);
 template unsigned int base_uint<256>::bits() const;
+template base_uint<256> base_uint<256>::UintToArith(const base_blob<256>& a) const;
+template base_blob<256> base_uint<256>::ArithToUint(const base_uint<256>& a) const;
 
 // This implementation directly uses shifts instead of going
 // through an intermediate MPI representation.
@@ -254,6 +275,39 @@ uint256 ArithToUint256(const arith_uint256 &a)
 arith_uint256 UintToArith256(const uint256 &a)
 {
     arith_uint256 b;
+    for(int x=0; x<b.WIDTH; ++x)
+        b.pn[x] = ReadLE32(a.begin() + x*4);
+    return b;
+}
+
+// Explicit instantiations for base_uint<512>
+template base_uint<512>::base_uint(const std::string&);
+template base_uint<512>& base_uint<512>::operator<<=(unsigned int);
+template base_uint<512>& base_uint<512>::operator>>=(unsigned int);
+template base_uint<512>& base_uint<512>::operator*=(uint32_t b32);
+template base_uint<512>& base_uint<512>::operator*=(const base_uint<512>& b);
+template base_uint<512>& base_uint<512>::operator/=(const base_uint<512>& b);
+template int base_uint<512>::CompareTo(const base_uint<512>&) const;
+template bool base_uint<512>::EqualTo(uint64_t) const;
+template double base_uint<512>::getdouble() const;
+template std::string base_uint<512>::GetHex() const;
+template std::string base_uint<512>::ToString() const;
+template void base_uint<512>::SetHex(const char*);
+template void base_uint<512>::SetHex(const std::string&);
+template unsigned int base_uint<512>::bits() const;
+template base_uint<512> base_uint<512>::UintToArith(const base_blob<512>& a) const;
+template base_blob<512> base_uint<512>::ArithToUint(const base_uint<512>& a) const;
+
+ uint512 ArithToUint512(const arith_uint512 &a)
+{
+    uint512 b;
+    for(int x=0; x<a.WIDTH; ++x)
+        WriteLE32(b.begin() + x*4, a.pn[x]);
+    return b;
+}
+arith_uint512 UintToArith512(const uint512 &a)
+{
+    arith_uint512 b;
     for(int x=0; x<b.WIDTH; ++x)
         b.pn[x] = ReadLE32(a.begin() + x*4);
     return b;

--- a/bitcoin/arith_uint256.h
+++ b/bitcoin/arith_uint256.h
@@ -12,6 +12,7 @@
 #include <stdint.h>
 #include <string>
 #include <vector>
+#include "uint256.h"
 
 class uint256;
 
@@ -236,6 +237,9 @@ public:
         return sizeof(pn);
     }
 
+    base_uint<BITS> UintToArith(const base_blob<BITS>& a) const;
+    base_blob<BITS> ArithToUint(const base_uint<BITS>& a) const;
+
     /**
      * Returns the position of the highest bit set plus one, or zero if the
      * value is zero.
@@ -295,7 +299,21 @@ public:
     friend arith_uint256 UintToArith256(const uint256 &);
 };
 
+/** 512-bit unsigned big integer. */
+class arith_uint512 : public base_uint<512> {
+public:
+    arith_uint512() {}
+    arith_uint512(const base_uint<512>& b) : base_uint<512>(b) {}
+    arith_uint512(uint64_t b) : base_uint<512>(b) {}
+    explicit arith_uint512(const std::string& str) : base_uint<512>(str) {}
+    friend uint512 ArithToUint512(const arith_uint512 &);
+    friend arith_uint512 UintToArith512(const uint512 &);
+};
+
 uint256 ArithToUint256(const arith_uint256 &);
 arith_uint256 UintToArith256(const uint256 &);
+
+uint512 ArithToUint512(const arith_uint512 &);
+arith_uint512 UintToArith512(const uint512 &);
 
 #endif // BITCOIN_ARITH_UINT256_H

--- a/bitcoin/hash.h
+++ b/bitcoin/hash.h
@@ -42,6 +42,17 @@ public:
     }
 };
 
+/** Compute the 256-bit hash of an object. */
+template<typename T1>
+inline uint256 Hash(const T1 pbegin, const T1 pend)
+{
+    static const unsigned char pblank[1] = {};
+    uint256 result;
+    CHash256().Write(pbegin == pend ? pblank : (const unsigned char*)&pbegin[0], (pend - pbegin) * sizeof(pbegin[0]))
+              .Finalize((unsigned char*)&result);
+    return result;
+}
+
 /** A writer stream (for serialization) that computes a 256-bit hash. */
 class CHashWriter
 {

--- a/bitcoin/uint256.cpp
+++ b/bitcoin/uint256.cpp
@@ -17,6 +17,12 @@ base_blob<BITS>::base_blob(const std::vector<unsigned char>& vch)
     memcpy(data, &vch[0], sizeof(data));
 }
 
+template<unsigned int BITS>
+base_blob<BITS>::base_blob(const std::array<unsigned char, WIDTH>& vch)
+{
+    memcpy(data, &vch[0], sizeof(data));
+}
+
 template <unsigned int BITS>
 std::string base_blob<BITS>::GetHex() const
 {
@@ -67,16 +73,55 @@ std::string base_blob<BITS>::ToString() const
     return (GetHex());
 }
 
+/* base_blob<BITS> from const char *.
+ * This is a separate function because the constructor base_blob<BITS>(const char*) can result
+ * in dangerously catching base_blob<BITS>(0).
+ */
+template <unsigned int BITS>
+base_blob<BITS> base_blob<BITS>::uintS(const char *str) const
+{
+    base_blob<BITS> rv;
+    rv.SetHex(str);
+    return rv;
+}
+/* base_blob<BITS> from std::string.
+ * This is a separate function because the constructor base_blob<BITS>(const std::string &str) can result
+ * in dangerously catching base_blob<BITS>(0) via std::string(const char*).
+ */
+template <unsigned int BITS>
+base_blob<BITS> base_blob<BITS>::uintS(const std::string& str) const
+{
+    base_blob<BITS> rv;
+    rv.SetHex(str);
+    return rv;
+}
+
 // Explicit instantiations for base_blob<160>
 template base_blob<160>::base_blob(const std::vector<unsigned char>&);
+template base_blob<160>::base_blob(const std::array<unsigned char, 20>&);
 template std::string base_blob<160>::GetHex() const;
 template std::string base_blob<160>::ToString() const;
+template base_blob<160> base_blob<160>::uintS(const char *str) const;
+template base_blob<160> base_blob<160>::uintS(const std::string& str) const;
 template void base_blob<160>::SetHex(const char*);
 template void base_blob<160>::SetHex(const std::string&);
 
 // Explicit instantiations for base_blob<256>
 template base_blob<256>::base_blob(const std::vector<unsigned char>&);
+template base_blob<256>::base_blob(const std::array<unsigned char, 32>&);
 template std::string base_blob<256>::GetHex() const;
 template std::string base_blob<256>::ToString() const;
+template base_blob<256> base_blob<256>::uintS(const char *str) const;
+template base_blob<256> base_blob<256>::uintS(const std::string& str) const;
 template void base_blob<256>::SetHex(const char*);
 template void base_blob<256>::SetHex(const std::string&);
+
+// Explicit instantiations for base_blob<512>
+template base_blob<512>::base_blob(const std::vector<unsigned char>&);
+template base_blob<512>::base_blob(const std::array<unsigned char, 64>&);
+template std::string base_blob<512>::GetHex() const;
+template std::string base_blob<512>::ToString() const;
+template base_blob<512> base_blob<512>::uintS(const char *str) const;
+template base_blob<512> base_blob<512>::uintS(const std::string& str) const;
+template void base_blob<512>::SetHex(const char*);
+template void base_blob<512>::SetHex(const std::string&);

--- a/bitcoin/uint256.h
+++ b/bitcoin/uint256.h
@@ -8,10 +8,12 @@
 
 #include <assert.h>
 #include <cstring>
+#include <functional>
 #include <stdexcept>
 #include <stdint.h>
 #include <string>
 #include <vector>
+#include <array>
 #include "crypto/common.h"
 
 /** Template base class for fixed-sized opaque blobs. */
@@ -28,6 +30,7 @@ public:
     }
 
     explicit base_blob(const std::vector<unsigned char>& vch);
+    explicit base_blob(const std::array<unsigned char, WIDTH>& vch);
 
     bool IsNull() const
     {
@@ -52,6 +55,8 @@ public:
     void SetHex(const char* psz);
     void SetHex(const std::string& str);
     std::string ToString() const;
+    base_blob<BITS> uintS(const char *str) const;
+    base_blob<BITS> uintS(const std::string& str) const;
 
     unsigned char* begin()
     {
@@ -162,5 +167,58 @@ inline uint256 uint256S(const std::string& str)
     rv.SetHex(str);
     return rv;
 }
+
+/** 512-bit opaque blob.
+ * @note This type is called uint512 for historical reasons only. It is an
+ * opaque blob of 512 bits and has no integer operations. Use arith_uint512 if
+ * those are required.
+ */
+class uint512 : public base_blob<512> {
+public:
+    uint512() {}
+    uint512(const base_blob<512>& b) : base_blob<512>(b) {}
+    explicit uint512(const std::vector<unsigned char>& vch) : base_blob<512>(vch) {}
+    explicit uint512(const std::array<unsigned char, 64>& vch) : base_blob<512>(vch) {}
+
+     /** A cheap hash function that just returns 64 bits from the result, it can be
+     * used when the contents are considered uniformly random. It is not appropriate
+     * when the value can easily be influenced from outside as e.g. a network adversary could
+     * provide values to trigger worst-case behavior.
+     */
+    uint64_t GetCheapHash() const
+    {
+        return ReadLE64(data);
+    }
+
+     uint256 trim256() const
+    {
+        uint256 ret;
+        memcpy(ret.begin(), (*this).begin(), ret.size());
+        return ret;
+    }
+};
+
+namespace std {
+
+template<unsigned Size>
+struct hash<base_blob<Size>>
+{
+    size_t operator()(const base_blob<Size>& b) const
+    {
+        return hash<string>()(string(b.begin(), b.end()));
+    }
+};
+
+template<>
+struct hash<uint256> : hash<base_blob<256>>
+{
+};
+
+template<>
+struct hash<uint160> : hash<base_blob<160>>
+{
+};
+
+} // namespace std
 
 #endif // BITCOIN_UINT256_H

--- a/src/coin.cpp
+++ b/src/coin.cpp
@@ -284,16 +284,16 @@ void PrivateCoin::mintCoin(const CoinDenomination denomination){
     publicCoin = PublicCoin(commit, denomination);
 }
 
-bool PrivateCoin::mintCoin(const CoinDenomination denomination, BIP44MintData data){
+bool PrivateCoin::mintCoin(const CoinDenomination denomination, const BIP44MintData data){
     // See https://github.com/zcoinofficial/zcoin/pull/392 for specification
     // HMAC-SHA512(SHA256(index),key)
     unsigned char countHash[CSHA256().OUTPUT_SIZE];
     std::vector<unsigned char> result(CSHA512().OUTPUT_SIZE);
 
-    std::string nCountStr = to_string(data.index);
+    std::string nCountStr = to_string(data.getIndex());
     CSHA256().Write(reinterpret_cast<const unsigned char*>(nCountStr.c_str()), nCountStr.size()).Finalize(countHash);
 
-    CHMAC_SHA512(countHash, CSHA256().OUTPUT_SIZE).Write(data.keydata, 32).Finalize(&result[0]);
+    CHMAC_SHA512(countHash, CSHA256().OUTPUT_SIZE).Write(data.getKeyData(), data.size()).Finalize(&result[0]);
 
     uint512 seed = uint512(result);
 

--- a/src/coin.h
+++ b/src/coin.h
@@ -28,6 +28,12 @@ enum class CoinDenomination : std::uint8_t {
     SIGMA_DENOM_100 = 4
 };
 
+struct BIP44MintData {
+    //! The actual byte data
+    unsigned char keydata[32];
+    const int32_t index;
+};
+
 // for LogPrintf.
 std::ostream& operator<<(std::ostream& stream, CoinDenomination denomination);
 
@@ -95,8 +101,8 @@ public:
 
      PrivateCoin(const Params* p,
         CoinDenomination denomination,
-        uint512 seed,
-        int version = 0);
+	BIP44MintData data,
+	int version = 0);
 
     const Params * getParams() const;
     const PublicCoin& getPublicCoin() const;
@@ -125,7 +131,7 @@ private:
     unsigned char ecdsaSeckey[32];
 
     void mintCoin(const CoinDenomination denomination);
-    bool mintCoin(const CoinDenomination denomination, uint512 seed);
+    bool mintCoin(const CoinDenomination denomination, BIP44MintData data);
 
 };
 

--- a/src/coin.h
+++ b/src/coin.h
@@ -5,6 +5,7 @@
 #include "sigma_primitives.h"
 #include "../secp256k1/include/secp256k1_ecdh.h"
 #include "../secp256k1/include/secp256k1.h"
+#include "../bitcoin/uint256.h"
 
 //#include "../consensus/validation.h"
 //#include "../libzerocoin/Zerocoin.h"
@@ -92,6 +93,11 @@ public:
         CoinDenomination denomination,
         int version = 0);
 
+     PrivateCoin(const Params* p,
+        CoinDenomination denomination,
+        uint512 seed,
+        int version = 0);
+
     const Params * getParams() const;
     const PublicCoin& getPublicCoin() const;
     const Scalar& getSerialNumber() const;
@@ -104,6 +110,7 @@ public:
     const unsigned char* getEcdsaSeckey() const;
 
     void setEcdsaSeckey(const std::vector<unsigned char> &seckey);
+    void setEcdsaSeckey(uint256 &seckey);
 
     static Scalar serialNumberFromSerializedPublicKey(
         const secp256k1_context *context,
@@ -118,6 +125,7 @@ private:
     unsigned char ecdsaSeckey[32];
 
     void mintCoin(const CoinDenomination denomination);
+    bool mintCoin(const CoinDenomination denomination, uint512 seed);
 
 };
 

--- a/src/coin.h
+++ b/src/coin.h
@@ -28,10 +28,22 @@ enum class CoinDenomination : std::uint8_t {
     SIGMA_DENOM_100 = 4
 };
 
-struct BIP44MintData {
-    //! The actual byte data
+class BIP44MintData {
+public:
+    BIP44MintData(unsigned char* keydata, int32_t index){
+        if(sizeof(keydata)!=32)
+            throw std::runtime_error("Invalid key size");
+        memcpy(this->keydata, keydata, 32);
+        this->index = index;
+    }
+
+    const unsigned char* getKeyData() const { return keydata; }
+    const int32_t getIndex() const {return index; }
+    unsigned int size() const { return 32; }
+
+private:
     unsigned char keydata[32];
-    const int32_t index;
+    int32_t index;
 };
 
 // for LogPrintf.
@@ -131,7 +143,7 @@ private:
     unsigned char ecdsaSeckey[32];
 
     void mintCoin(const CoinDenomination denomination);
-    bool mintCoin(const CoinDenomination denomination, BIP44MintData data);
+    bool mintCoin(const CoinDenomination denomination, const BIP44MintData data);
 
 };
 


### PR DESCRIPTION
Create a mint by passing a BIP44 mint key to the `PrivateCoin` object, generating a 512 bit seed following the HD mint spec from [here](https://github.com/zcoinofficial/zcoin/pull/392), and using this seed to generate the serial number and randomness, rather than generating randomly. This is the same functionality that takes place in the HD mint code. This is needed for the mobile wallet.

On analysis of the code it looks like a lot of the HD mint functionality for the mobile wallet will have to be written in JS. The essential part is relatively small, and doesn't justify adding a whole other library. So I think it's best to include that here.

## code changes
- added needed dependancies to `bitcoin/`: 
     - Updating uint256 files to include 512-bit support
     - adding a 256-bit hash function to `hash.h`

- new `PrivateCoin` and `mintCoin` functions 
